### PR TITLE
Improve QEMU startup script

### DIFF
--- a/emulate_and_trace.sh
+++ b/emulate_and_trace.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-qemu-system-arm \
+setsid qemu-system-arm \
   -M virt \
   -cpu cortex-a15 \
   -kernel openwrt-22.03.5-armvirt-32-zImage \
@@ -10,5 +10,8 @@ qemu-system-arm \
   -fsdev local,id=host0,path=$(pwd),security_model=none \
   -device virtio-9p-device,fsdev=host0,mount_tag=hostshare \
   -netdev user,id=net0 \
-  -device virtio-net-device,netdev=net0
+  -device virtio-net-device,netdev=net0 \
+  </dev/null &>run.log &
+
+echo "QEMU started in the background. Console output is in run.log"
 


### PR DESCRIPTION
## Summary
- ensure `emulate_and_trace.sh` launches QEMU as a background process
- pipe QEMU console output to `run.log`

## Testing
- `./emulate_and_trace.sh`
- `ps aux | grep qemu | head -n 5`
- `tail -n 10 run.log`


------
https://chatgpt.com/codex/tasks/task_e_683f5866f0748326a4f6c73b3746ae20